### PR TITLE
Change format of zero types

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         run: go test -race -coverprofile=coverage.txt -covermode=atomic
        
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Set up Go
-        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version: ${{ matrix.go-version }}
           cache: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,5 +34,5 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Golangci-lint
-        uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0
+        uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ func main() {
 	var d = godump.Dumper{
 		Indentation:       "  ",
 		HidePrivateFields: false,
+		ShowPrimitiveNamedTypes = false
 		Theme: godump.Theme{
 			String: godump.RGB{R: 138, G: 201, B: 38},
 			// ...

--- a/dumper.go
+++ b/dumper.go
@@ -222,16 +222,12 @@ func (d *Dumper) dump(val reflect.Value, ignoreDepth ...bool) {
 	case reflect.Interface:
 		d.dump(val.Elem(), true)
 	case reflect.UnsafePointer:
-		if t := val.Type(); t.PkgPath() != "" {
-			d.buf.WriteString(
-				__(d.Theme.Types, t.String()) +
-					__(d.Theme.Braces, "(") +
-					__(d.Theme.UnsafePointer, fmt.Sprintf("0x%x", uintptr(val.UnsafePointer()))) +
-					__(d.Theme.Braces, ")"),
-			)
-		} else {
-			d.buf.WriteString(__(d.Theme.UnsafePointer, fmt.Sprintf("unsafe.Pointer(0x%x)", uintptr(val.UnsafePointer()))))
-		}
+		d.buf.WriteString(
+			__(d.Theme.Types, val.Type().String()) +
+				__(d.Theme.Braces, "(") +
+				__(d.Theme.UnsafePointer, fmt.Sprintf("0x%x", uintptr(val.UnsafePointer()))) +
+				__(d.Theme.Braces, ")"),
+		)
 	}
 }
 

--- a/dumper.go
+++ b/dumper.go
@@ -274,6 +274,12 @@ func (d *Dumper) dumpMap(v reflect.Value) {
 		d.ptrTag = 0
 	}
 
+	if v.IsNil() {
+		d.buf.WriteString(__(d.Theme.Types, v.Type().String()) + __(d.Theme.Braces, "(") +
+			__(d.Theme.Nil, "nil") + __(d.Theme.Braces, ")"+tag))
+		return
+	}
+
 	d.buf.WriteString(__(d.Theme.Types, fmt.Sprintf("%s:%d", v.Type(), len(keys))))
 	d.buf.WriteString(__(d.Theme.Braces, fmt.Sprintf(" {%s", tag)))
 

--- a/dumper.go
+++ b/dumper.go
@@ -240,6 +240,12 @@ func (d *Dumper) dumpSlice(v reflect.Value) {
 		d.ptrTag = 0
 	}
 
+	if v.IsNil() {
+		d.buf.WriteString(__(d.Theme.Types, v.Type().String()) + __(d.Theme.Braces, "(") +
+			__(d.Theme.Nil, "nil") + __(d.Theme.Braces, ") "+tag))
+		return
+	}
+
 	d.buf.WriteString(__(d.Theme.Types, fmt.Sprintf("%s:%d:%d", v.Type(), length, v.Cap())))
 	d.buf.WriteString(__(d.Theme.Braces, fmt.Sprintf(" {%s", tag)))
 

--- a/dumper.go
+++ b/dumper.go
@@ -242,7 +242,7 @@ func (d *Dumper) dumpSlice(v reflect.Value) {
 
 	if v.IsNil() {
 		d.buf.WriteString(__(d.Theme.Types, v.Type().String()) + __(d.Theme.Braces, "(") +
-			__(d.Theme.Nil, "nil") + __(d.Theme.Braces, ") "+tag))
+			__(d.Theme.Nil, "nil") + __(d.Theme.Braces, ")"+tag))
 		return
 	}
 

--- a/dumper.go
+++ b/dumper.go
@@ -199,13 +199,13 @@ func (d *Dumper) dump(val reflect.Value, ignoreDepth ...bool) {
 	case reflect.Func:
 		d.buf.WriteString(__(d.Theme.Func, val.Type().String()))
 		if val.IsNil() {
-			d.buf.WriteString(__(d.Theme.Braces, "(") + __(d.Theme.Nil, "nil") + __(d.Theme.Braces, ")"))
+			d.writeNil()
 		}
 	case reflect.Chan:
 		d.buf.WriteString(__(d.Theme.Chan, val.Type().String()))
 
 		if val.IsNil() {
-			d.buf.WriteString(__(d.Theme.Braces, "(") + __(d.Theme.Nil, "nil") + __(d.Theme.Braces, ")"))
+			d.writeNil()
 		}
 
 		if vCap := val.Cap(); vCap > 0 {
@@ -249,8 +249,9 @@ func (d *Dumper) dumpSlice(v reflect.Value) {
 	}
 
 	if v.IsNil() {
-		d.buf.WriteString(__(d.Theme.Types, v.Type().String()) + __(d.Theme.Braces, "(") +
-			__(d.Theme.Nil, "nil") + __(d.Theme.Braces, ")"+tag))
+		d.buf.WriteString(__(d.Theme.Types, v.Type().String()))
+		d.writeNil()
+		d.buf.WriteString(tag)
 		return
 	}
 
@@ -283,8 +284,9 @@ func (d *Dumper) dumpMap(v reflect.Value) {
 	}
 
 	if v.IsNil() {
-		d.buf.WriteString(__(d.Theme.Types, v.Type().String()) + __(d.Theme.Braces, "(") +
-			__(d.Theme.Nil, "nil") + __(d.Theme.Braces, ")"+tag))
+		d.buf.WriteString(__(d.Theme.Types, v.Type().String()))
+		d.writeNil()
+		d.buf.WriteString(tag)
 		return
 	}
 
@@ -311,7 +313,8 @@ func (d *Dumper) dumpMap(v reflect.Value) {
 
 func (d *Dumper) dumpPointer(v reflect.Value) {
 	if v.IsNil() {
-		d.buf.WriteString(__(d.Theme.Types, v.Type().String()) + __(d.Theme.Braces, "(") + __(d.Theme.Nil, "nil") + __(d.Theme.Braces, ")"))
+		d.buf.WriteString(__(d.Theme.Types, v.Type().String()))
+		d.writeNil()
 		return
 	}
 
@@ -414,4 +417,8 @@ func (d *Dumper) wrapType(v reflect.Value, str string) {
 	}
 
 	d.buf.WriteString(str)
+}
+
+func (d *Dumper) writeNil() {
+	d.buf.WriteString(__(d.Theme.Braces, "(") + __(d.Theme.Nil, "nil") + __(d.Theme.Braces, ")"))
 }

--- a/dumper.go
+++ b/dumper.go
@@ -198,6 +198,9 @@ func (d *Dumper) dump(val reflect.Value, ignoreDepth ...bool) {
 		d.dumpMap(val)
 	case reflect.Func:
 		d.buf.WriteString(__(d.Theme.Func, val.Type().String()))
+		if val.IsNil() {
+			d.buf.WriteString(__(d.Theme.Braces, "(") + __(d.Theme.Nil, "nil") + __(d.Theme.Braces, ")"))
+		}
 	case reflect.Chan:
 		d.buf.WriteString(__(d.Theme.Chan, val.Type().String()))
 

--- a/dumper.go
+++ b/dumper.go
@@ -200,6 +200,11 @@ func (d *Dumper) dump(val reflect.Value, ignoreDepth ...bool) {
 		d.buf.WriteString(__(d.Theme.Func, val.Type().String()))
 	case reflect.Chan:
 		d.buf.WriteString(__(d.Theme.Chan, val.Type().String()))
+
+		if val.IsNil() {
+			d.buf.WriteString(__(d.Theme.Braces, "(") + __(d.Theme.Nil, "nil") + __(d.Theme.Braces, ")"))
+		}
+
 		if vCap := val.Cap(); vCap > 0 {
 			d.buf.WriteString(__(d.Theme.Chan, fmt.Sprintf("<%d>", vCap)))
 		}

--- a/dumper.go
+++ b/dumper.go
@@ -310,6 +310,11 @@ func (d *Dumper) dumpMap(v reflect.Value) {
 }
 
 func (d *Dumper) dumpPointer(v reflect.Value) {
+	if v.IsNil() {
+		d.buf.WriteString(__(d.Theme.Types, v.Type().String()) + __(d.Theme.Braces, "(") + __(d.Theme.Nil, "nil") + __(d.Theme.Braces, ")"))
+		return
+	}
+
 	elem := v.Elem()
 
 	if isPrimitive(elem) {

--- a/dumper_test.go
+++ b/dumper_test.go
@@ -183,6 +183,8 @@ func TestCanDumpPrimitives(t *testing.T) {
 		PtrTypedFunc3 *Func3Type
 		PtrTypedFunc4 *Func4Type
 
+		NilFunc func()
+
 		Chan  chan struct{}
 		Chan1 <-chan struct{}
 		Chan2 chan<- struct{}
@@ -318,6 +320,16 @@ func TestCanDumpPrimitives(t *testing.T) {
 	node.PtrTypedString = &node.TypedString
 
 	node.PtrTypedUintptr = &node.TypedUintptr
+
+	node.Func = func() {}
+	node.Func2 = func(int) float64 { return 0 }
+	node.Func3 = func(a ...*any) any { return nil }
+	node.Func4 = func(_ byte, _ ...[]*complex128) bool { return false }
+
+	node.TypedFunc = func() {}
+	node.TypedFunc2 = func(int) float64 { return 0 }
+	node.TypedFunc3 = func(a ...*any) any { return nil }
+	node.TypedFunc4 = func(_ byte, _ ...[]*complex128) bool { return false }
 
 	node.FuncPtr = &node.Func
 	node.Func2Ptr = &node.Func2

--- a/dumper_test.go
+++ b/dumper_test.go
@@ -751,6 +751,8 @@ func TestCanDumpMaps(t *testing.T) {
 	type SomeMap map[*SomeMap]*SomeMap
 	sm := &SomeMap{}
 
+	var nilMap SomeMap
+
 	m := map[any]any{12: 34}
 	maps := []any{
 		make(map[string]string),
@@ -763,6 +765,7 @@ func TestCanDumpMaps(t *testing.T) {
 		SomeMap{
 			&SomeMap{}: &SomeMap{sm: sm},
 		},
+		nilMap,
 	}
 
 	var d godump.Dumper

--- a/dumper_test.go
+++ b/dumper_test.go
@@ -714,6 +714,8 @@ func TestCanDumpPrivateStructs(t *testing.T) {
 func TestCanDumpSlices(t *testing.T) {
 	type Slice []any
 
+	var nilSLice []Slice
+
 	foo := "foo"
 	bar := "bar"
 	baz := "baz"
@@ -735,6 +737,7 @@ func TestCanDumpSlices(t *testing.T) {
 			false,
 		},
 		make([]any, 3, 8),
+		nilSLice,
 	}
 	s = append(s, &s)
 

--- a/dumper_test.go
+++ b/dumper_test.go
@@ -200,6 +200,7 @@ func TestCanDumpPrimitives(t *testing.T) {
 		PtrTypedChan2 *Chan2Type
 
 		BufferedChan chan struct{}
+		NilChan      chan struct{}
 
 		UnsafePointer1     unsafe.Pointer
 		UnsafePointer2     *unsafe.Pointer
@@ -252,6 +253,9 @@ func TestCanDumpPrimitives(t *testing.T) {
 		UnsafePointer1:     nil,
 		NamedUnsafePointer: nil,
 
+		Chan:         make(chan struct{}),
+		Chan1:        make(chan struct{}),
+		Chan2:        make(chan struct{}),
 		BufferedChan: make(chan struct{}, 255),
 	}
 

--- a/dumper_test.go
+++ b/dumper_test.go
@@ -161,7 +161,7 @@ func TestCanDumpPrimitives(t *testing.T) {
 
 		PtrTypedUintptr *UintptrType
 
-		Nil *any
+		NilPointer *int
 
 		Func  func()
 		Func2 func(int) float64
@@ -249,8 +249,6 @@ func TestCanDumpPrimitives(t *testing.T) {
 		TypedString:     StringType("foo bar"),
 
 		TypedUintptr: UintptrType(1234567890),
-
-		Nil: nil,
 
 		UnsafePointer1:     nil,
 		NamedUnsafePointer: nil,

--- a/dumper_test.go
+++ b/dumper_test.go
@@ -321,13 +321,13 @@ func TestCanDumpPrimitives(t *testing.T) {
 
 	node.Func = func() {}
 	node.Func2 = func(int) float64 { return 0 }
-	node.Func3 = func(a ...*any) any { return nil }
-	node.Func4 = func(_ byte, _ ...[]*complex128) bool { return false }
+	node.Func3 = func(...*any) any { return nil }
+	node.Func4 = func(byte, ...[]*complex128) bool { return false }
 
 	node.TypedFunc = func() {}
 	node.TypedFunc2 = func(int) float64 { return 0 }
-	node.TypedFunc3 = func(a ...*any) any { return nil }
-	node.TypedFunc4 = func(_ byte, _ ...[]*complex128) bool { return false }
+	node.TypedFunc3 = func(...*any) any { return nil }
+	node.TypedFunc4 = func(byte, ...[]*complex128) bool { return false }
 
 	node.FuncPtr = &node.Func
 	node.Func2Ptr = &node.Func2

--- a/dumper_test.go
+++ b/dumper_test.go
@@ -728,7 +728,7 @@ func TestCanDumpPrivateStructs(t *testing.T) {
 func TestCanDumpSlices(t *testing.T) {
 	type Slice []any
 
-	var nilSLice []Slice
+	var nilSlice []Slice
 
 	foo := "foo"
 	bar := "bar"
@@ -751,7 +751,7 @@ func TestCanDumpSlices(t *testing.T) {
 			false,
 		},
 		make([]any, 3, 8),
-		nilSLice,
+		nilSlice,
 	}
 	s = append(s, &s)
 

--- a/testdata/maps.txt
+++ b/testdata/maps.txt
@@ -1,4 +1,4 @@
-[]interface {}:4:4 {
+[]interface {}:5:5 {
    map[string]string:0 {},
    map[interface {}]int:1 {
       &map[interface {}]interface {}:1 {#1
@@ -13,4 +13,5 @@
          &godump_test.SomeMap:0 {#4}: &@4,
       },
    },
+   godump_test.SomeMap(nil),
 }

--- a/testdata/primitives.txt
+++ b/testdata/primitives.txt
@@ -106,6 +106,7 @@ godump_test.Node {
    PtrTypedFunc2: &godump_test.Func2Type,
    PtrTypedFunc3: &godump_test.Func3Type,
    PtrTypedFunc4: &godump_test.Func4Type,
+   NilFunc: func()(nil),
    Chan: chan struct {},
    Chan1: <-chan struct {},
    Chan2: chan<- struct {},

--- a/testdata/primitives.txt
+++ b/testdata/primitives.txt
@@ -119,6 +119,7 @@ godump_test.Node {
    PtrTypedChan1: &godump_test.Chan1Type,
    PtrTypedChan2: &godump_test.Chan2Type,
    BufferedChan: chan struct {}<255>,
+   NilChan: chan struct {}(nil),
    UnsafePointer1: unsafe.Pointer(0x0),
    UnsafePointer2: &unsafe.Pointer(0x7b),
    NamedUnsafePointer: godump_test.UnsafePointer(0x0),

--- a/testdata/primitives.txt
+++ b/testdata/primitives.txt
@@ -89,7 +89,7 @@ godump_test.Node {
    PtrTypedBool2: &false,
    PtrTypedString: &"foo bar",
    PtrTypedUintptr: &0x499602d2,
-   Nil: nil,
+   NilPointer: *int(nil),
    Func: func(),
    Func2: func(int) float64,
    Func3: func(...*interface {}) interface {},

--- a/testdata/slices.txt
+++ b/testdata/slices.txt
@@ -1,4 +1,4 @@
-godump_test.Slice:10:18 {
+godump_test.Slice:11:20 {
    1,
    2.3,
    true,
@@ -19,7 +19,8 @@ godump_test.Slice:10:18 {
       nil,
       nil,
    },
-   &godump_test.Slice:10:18 {#2
+   []godump_test.Slice(nil),
+   &godump_test.Slice:11:20 {#2
       1,
       2.3,
       true,
@@ -37,6 +38,7 @@ godump_test.Slice:10:18 {
          nil,
          nil,
       },
+      []godump_test.Slice(nil),
       &@2,
    },
 }


### PR DESCRIPTION
What is this PR?
= It changes the format of nil maps, slices,  functions, pointers and channels

What was changed?
-  Slices:

    ```go
    var x []int
    var y = make([]int, 0)
    ```
    Before:
    ```txt
    []int:0:0 {}
    []int:0:0 {}
    ```
    Now:
    ```txt
    []int(nil)
    []int:0:0 {}
    ```
-  Maps:

    ```go
    var x map[string]int
    var y = make(map[string]int)
    ```
    Before:
    ```txt
    map[string]int:0 {}
    map[string]int:0 {}
    ```
    Now:
    ```txt
    map[string]int(nil)
    map[string]int:0 {}
    ```
-  Channels:

    ```go
    var x chan string
    var y = make(chan string)
    ```
    Before:
    ```txt
    chan string
    chan string
    ```
    Now:
    ```txt
    chan string(nil)
    chan string
    ```
-  Functions:

    ```go
    var x func()
    var y = func(){}
    ```
    Before:
    ```txt
    func()
    func()
    ```
    Now:
    ```txt
    func()(nil)
    func()
    ```
-  Pointers:

    ```go
    var x *int
    var y = &x
    ```
    Before:
    ```txt
    nil
    &nil
    ```
    Now:
    ```txt
    *int(nil)
    &*int(nil)
    ```

Why would we need to this?
= Some people like myself are using `godump` in tests for logging, and we compare two data structures using `reflect.DeepEqual()`, When comparing a nil slice with a slice of zero length and capacity, they are not equal, but they look the same in logs. 

Why there are changes in workflows?
= I don't know, I did a git rebase to solve some issues and I think they caused the 3 first commits not to be recognized in master (hash may have changed).  