### PR TITLE
Fix panic when input is array

### DIFF
--- a/dumper.go
+++ b/dumper.go
@@ -240,20 +240,20 @@ func (d *Dumper) dump(val reflect.Value, ignoreDepth ...bool) {
 }
 
 func (d *Dumper) dumpSlice(v reflect.Value) {
-	length := v.Len()
-
 	var tag string
 	if d.ptrTag != 0 {
 		tag = __(d.Theme.PointerTag, fmt.Sprintf("#%d", d.ptrTag))
 		d.ptrTag = 0
 	}
 
-	if v.IsNil() {
+	if v.Kind() == reflect.Slice && v.IsNil() {
 		d.buf.WriteString(__(d.Theme.Types, v.Type().String()))
 		d.writeNil()
 		d.buf.WriteString(tag)
 		return
 	}
+
+	length := v.Len()
 
 	d.buf.WriteString(__(d.Theme.Types, fmt.Sprintf("%s:%d:%d", v.Type(), length, v.Cap())))
 	d.buf.WriteString(__(d.Theme.Braces, fmt.Sprintf(" {%s", tag)))

--- a/dumper.go
+++ b/dumper.go
@@ -246,16 +246,20 @@ func (d *Dumper) dumpSlice(v reflect.Value) {
 		d.ptrTag = 0
 	}
 
-	if v.Kind() == reflect.Slice && v.IsNil() {
-		d.buf.WriteString(__(d.Theme.Types, v.Type().String()))
-		d.writeNil()
-		d.buf.WriteString(tag)
-		return
-	}
-
 	length := v.Len()
 
-	d.buf.WriteString(__(d.Theme.Types, fmt.Sprintf("%s:%d:%d", v.Type(), length, v.Cap())))
+	if v.Kind() == reflect.Slice {
+		if v.IsNil() {
+			d.buf.WriteString(__(d.Theme.Types, v.Type().String()))
+			d.writeNil()
+			d.buf.WriteString(tag)
+			return
+		}
+		d.buf.WriteString(__(d.Theme.Types, fmt.Sprintf("%s:%d:%d", v.Type(), length, v.Cap())))
+	} else {
+		d.buf.WriteString(__(d.Theme.Types, v.Type().String()))
+	}
+
 	d.buf.WriteString(__(d.Theme.Braces, fmt.Sprintf(" {%s", tag)))
 
 	d.depth++

--- a/dumper_test.go
+++ b/dumper_test.go
@@ -729,6 +729,7 @@ func TestCanDumpSlices(t *testing.T) {
 	type Slice []any
 
 	var nilSlice []Slice
+	var zeroArray [2]any
 
 	foo := "foo"
 	bar := "bar"
@@ -752,6 +753,8 @@ func TestCanDumpSlices(t *testing.T) {
 		},
 		make([]any, 3, 8),
 		nilSlice,
+		[2]int{1, 2},
+		zeroArray,
 	}
 	s = append(s, &s)
 

--- a/testdata/slices.txt
+++ b/testdata/slices.txt
@@ -20,11 +20,11 @@ godump_test.Slice:13:24 {
       nil,
    },
    []godump_test.Slice(nil),
-   [2]int:2:2 {
+   [2]int {
       1,
       2,
    },
-   [2]interface {}:2:2 {
+   [2]interface {} {
       nil,
       nil,
    },
@@ -47,11 +47,11 @@ godump_test.Slice:13:24 {
          nil,
       },
       []godump_test.Slice(nil),
-      [2]int:2:2 {
+      [2]int {
          1,
          2,
       },
-      [2]interface {}:2:2 {
+      [2]interface {} {
          nil,
          nil,
       },

--- a/testdata/slices.txt
+++ b/testdata/slices.txt
@@ -1,4 +1,4 @@
-godump_test.Slice:11:20 {
+godump_test.Slice:13:24 {
    1,
    2.3,
    true,
@@ -20,7 +20,15 @@ godump_test.Slice:11:20 {
       nil,
    },
    []godump_test.Slice(nil),
-   &godump_test.Slice:11:20 {#2
+   [2]int:2:2 {
+      1,
+      2,
+   },
+   [2]interface {}:2:2 {
+      nil,
+      nil,
+   },
+   &godump_test.Slice:13:24 {#2
       1,
       2.3,
       true,
@@ -39,6 +47,14 @@ godump_test.Slice:11:20 {
          nil,
       },
       []godump_test.Slice(nil),
+      [2]int:2:2 {
+         1,
+         2,
+      },
+      [2]interface {}:2:2 {
+         nil,
+         nil,
+      },
       &@2,
    },
 }


### PR DESCRIPTION
As reported at: https://github.com/davecgh/go-spew/issues/143#issuecomment-2480800686.

When input is an array, trying to call `v.IsNil()` will panic.

Also changed the array format to remove the capacity and length : 

```diff
- [2]int:2:2 { ...
+ [2]int { ...
```